### PR TITLE
Fix: Decline superfluous-actions for create-pull-request

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -365,6 +365,12 @@ runs:
       if: env.CHANGES_DETECTED == 'true'
       id: unified-change
       # yamllint disable rule:line-length
+      # zizmor: ignore[superfluous-actions] the action is not a thin
+      # wrapper around 'gh pr create': it stages and commits changes,
+      # reuses an existing branch, force-updates an open pull request
+      # in place rather than opening duplicates, and no-ops when there
+      # is nothing to commit. It is pinned to a commit SHA and tracked
+      # by Dependabot.
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
## Why

`zizmor`'s `superfluous-actions` audit reports `peter-evans/create-pull-request` and suggests calling `gh pr create` from a script step instead. This **declines** that deliberately rather than leaving the finding to block the gate.

The action is not a thin wrapper around one CLI call. It stages and commits changes, creates or reuses a branch, force-updates an existing pull request in place rather than opening duplicates, and does nothing when there is nothing to commit. Replacing it means re-solving branch reuse and idempotency in shell — more code, carrying more ways to go wrong. The audit reports **Low confidence** precisely because it cannot see that distinction.

The supply-chain argument for dropping a third-party action is already addressed by other means: the reference is pinned to a commit SHA and Dependabot maintains it.

Surfaced by lowering the organisation `zizmor` floor to `informational`; the finding predates that change.
